### PR TITLE
Fixing sudoers example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ zabbix	ALL=(ALL)  NOPASSWD:ALL
 Defaults:zabbix !syslog
 Defaults:zabbix !requiretty
 
-zabbix	ALL=(ALL)  NOPASSWD:lsof *
-zabbix	ALL=(ALL)  NOPASSWD:ps *
+zabbix ALL=(ALL) NOPASSWD: /usr/bin/lsof *
+zabbix ALL=(ALL) NOPASSWD: /bin/ps *
 ~#
 ```
 


### PR DESCRIPTION
Update only the sudors example. The old way trigger this:

```
sudo: no valid sudoers sources found, quitting
sudo: unable to initialize policy plugin
```